### PR TITLE
Add links to take/serverkit-login_items

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ $ serverkit apply recipe.yml
  - [serverkit-homebrew](https://github.com/r7kamura/serverkit-homebrew)
  - [serverkit-karabiner](https://github.com/r7kamura/serverkit-karabiner)
  - [serverkit-rbenv](https://github.com/r7kamura/serverkit-rbenv)
+ - [serverkit-login_items](https://github.com/take/serverkit-login_items)
 - [Vagrant integration](/doc/vagrant_integration.md)
 
 ## Similar tools

--- a/doc/plug_in.md
+++ b/doc/plug_in.md
@@ -14,4 +14,5 @@ gem "serverkit-defaults"
 gem "serverkit-homebrew"
 gem "serverkit-karabiner"
 gem "serverkit-rbenv"
+gem "serverkit-login_items"
 ```


### PR DESCRIPTION
I've created a plugin for Mac OSX's login items, and would be awesome if you can add the link :D.
BTW I don't mind if this repo goes under the serverkit org, as long as my name stays under the authors list.

Thanks!
