### PR TITLE
Expand symlink path

### DIFF
--- a/lib/serverkit/resources/symlink.rb
+++ b/lib/serverkit/resources/symlink.rb
@@ -23,6 +23,14 @@ module Serverkit
       def default_id
         source
       end
+
+      def destination
+        ::File.expand_path(attributes["destination"])
+      end
+
+      def source
+        ::File.expand_path(attributes["source"])
+      end
     end
   end
 end


### PR DESCRIPTION
I prefer

``` yaml
  <%- dotfiles.each do |path| -%>
  - type: symlink
    destination: ~/src/github.com/k0kubun/dotfiles/linked/<%= path %>
    source: ~/<%= path %>
  <%- end -%>
```

rather than

``` yaml
  <%- dotfiles.each do |path| -%>
  - type: symlink
    destination: /Users/<%= ENV["USER"] %>/src/github.com/k0kubun/dotfiles/linked/<%= path %>
    source: /Users/<%= ENV["USER"] %>/<%= path %>
  <%- end -%>
```
