### PR TITLE
Request pty by default

### DIFF
--- a/lib/serverkit/backends/ssh_backend.rb
+++ b/lib/serverkit/backends/ssh_backend.rb
@@ -25,6 +25,7 @@ module Serverkit
         @specinfra_backend ||= ::Specinfra::Backend::Ssh.new(
           host: host,
           ssh_options: ssh_options,
+          request_pty: true,
         )
       end
 


### PR DESCRIPTION
Without the option, `Specinfra::Backend::Ssh` aborts when running `sudo` command on remote hosts which require tty.

See
- https://github.com/mizzy/specinfra/blob/6251b95ad5e4a84c8c0c271baecc41eac6584cc3/lib/specinfra/backend/ssh.rb#L115-L119
- https://github.com/mizzy/specinfra/blob/6251b95ad5e4a84c8c0c271baecc41eac6584cc3/lib/specinfra/backend/ssh.rb#L139
