### PR TITLE
call `sudo -H` to set HOME

### DIFF
--- a/lib/serverkit/resources/base.rb
+++ b/lib/serverkit/resources/base.rb
@@ -233,7 +233,7 @@ module Serverkit
           command = "cd && #{command}"
         end
         unless user.nil?
-          command = "sudo -u #{user} -- /bin/sh -c #{Shellwords.escape(command)}"
+          command = "sudo -H -u #{user} -- /bin/sh -c #{Shellwords.escape(command)}"
         end
         backend.run_command(command)
       end


### PR DESCRIPTION
`cd` moves to HOME of the sudo-ing user but HOME environment variable is
still sudo-ed user's. This may fail if sudo-ing user can't read the
directory.
