### PR TITLE
Use Ruby v2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - 2.2.0
+  - 2.3.0


### PR DESCRIPTION
Since High Sierra uses Ruby v2.3, let's upgrade Ruby version.

```console
$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.13.6
BuildVersion:	17G7024

$ /usr/bin/ruby --version
ruby 2.3.7p456 (2018-03-28 revision 63024) [universal.x86_64-darwin17]
```
