### PR TITLE
Use activesupport v5.0+

### DIFF
--- a/serverkit.gemspec
+++ b/serverkit.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.0.0"
 
   spec.add_runtime_dependency "activemodel"
-  spec.add_runtime_dependency "activesupport", "< 5.0.0"
+  spec.add_runtime_dependency "activesupport", ">= 5.0.0"
   spec.add_runtime_dependency "bundler"
   spec.add_runtime_dependency "hashie"
   spec.add_runtime_dependency "highline"

--- a/serverkit.gemspec
+++ b/serverkit.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.bindir                = "bin"
   spec.executables           = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths         = ["lib"]
-  spec.required_ruby_version = ">= 2.0.0"
+  spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_runtime_dependency "activemodel"
   spec.add_runtime_dependency "activesupport", ">= 5.0.0"


### PR DESCRIPTION
Not sure why `activesupport` v4.x is used, but could we use v5.x by using Ruby 2.3 (related. #18 ) ❓ 

ref. https://github.com/serverkit/serverkit/commit/5adc4b69e62a24475c7fcb07dc15240b0ffd4d0a