### PR TITLE
Relax dependencies

### DIFF
--- a/serverkit.gemspec
+++ b/serverkit.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "specinfra", ">= 2.31.0"
   spec.add_runtime_dependency "unix-crypt"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "~> 11.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rubocop", "0.29.1"
 end

--- a/serverkit.gemspec
+++ b/serverkit.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "slop", "~> 3.4"
   spec.add_runtime_dependency "specinfra", ">= 2.31.0"
   spec.add_runtime_dependency "unix-crypt"
-  spec.add_development_dependency "pry", "0.10.1"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "3.2.0"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
   spec.add_development_dependency "rubocop", "0.29.1"
 end


### PR DESCRIPTION
Any reason locking the gems for development? Let's relax dependencies.

The reason why I lock rake v11 is current rubocop version(v0.29) requires rake v11. The warning message is:

```
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
```