### PR TITLE
Update rubocop gem to v0.50

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,9 @@ Style/Documentation:
 Style/DoubleNegation:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+  
 Style/FormatString:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.3
+
 Lint/AssignmentInCondition:
   Enabled: false
 
@@ -68,7 +71,7 @@ Style/PredicateName:
   Enabled: false
 
 Style/RegexpLiteral:
-  MaxSlashes: 0
+  AllowInnerSlashes: false
 
 Style/SignalException:
   Enabled: false
@@ -76,7 +79,10 @@ Style/SignalException:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
   Enabled: false
 
 Style/TrivialAccessors:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,9 @@ Lint/UnusedMethodArgument:
 Metrics/AbcSize:
   Enabled: false
 
+Metrics/BlockLength:
+  Enabled: false
+
 Metrics/ClassLength:
   Enabled: false
 
@@ -37,7 +40,10 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Enabled: false
 
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
+  Enabled: false
+
+Naming/PredicateName:
   Enabled: false
 
 Style/AndOr:
@@ -47,6 +53,9 @@ Style/Documentation:
   Enabled: false
 
 Style/DoubleNegation:
+  Enabled: false
+
+Style/EmptyMethod:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
@@ -70,9 +79,6 @@ Style/MultilineBlockChain:
 Style/PercentLiteralDelimiters:
   Enabled: false
 
-Style/PredicateName:
-  Enabled: false
-
 Style/RegexpLiteral:
   AllowInnerSlashes: false
 
@@ -81,6 +87,9 @@ Style/SignalException:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+
+Style/SymbolArray:
+  Enabled: false
 
 Style/TrailingCommaInLiteral:
   Enabled: false

--- a/lib/serverkit/backends/local_backend.rb
+++ b/lib/serverkit/backends/local_backend.rb
@@ -4,7 +4,7 @@ require "specinfra"
 module Serverkit
   module Backends
     class LocalBackend < BaseBackend
-      HOST = "localhost"
+      HOST = "localhost".freeze
 
       # @note Override
       def host

--- a/lib/serverkit/backends/ssh_backend.rb
+++ b/lib/serverkit/backends/ssh_backend.rb
@@ -6,7 +6,7 @@ require "specinfra"
 module Serverkit
   module Backends
     class SshBackend < BaseBackend
-      DEFAULT_SSH_OPTIONS = {}
+      DEFAULT_SSH_OPTIONS = {}.freeze
 
       attr_reader :host
 

--- a/lib/serverkit/command.rb
+++ b/lib/serverkit/command.rb
@@ -28,7 +28,7 @@ module Serverkit
       "FATAL" => Logger::FATAL,
       "INFO" => Logger::INFO,
       "WARN" => Logger::WARN,
-    }
+    }.freeze
 
     # @param [Array<String>] argv
     def initialize(argv)

--- a/lib/serverkit/loaders/base_loader.rb
+++ b/lib/serverkit/loaders/base_loader.rb
@@ -16,12 +16,11 @@ module Serverkit
       end
 
       def load
-        case
-        when !pathname.exist?
+        if !pathname.exist?
           raise Errors::NonExistentPathError, pathname
-        when has_directory_path?
+        elsif has_directory_path?
           load_from_directory
-        when has_erb_path?
+        elsif has_erb_path?
           load_from_erb
         else
           load_from_data
@@ -90,10 +89,9 @@ module Serverkit
 
       # @return [Hash]
       def load_data
-        case
-        when has_executable_path?
+        if has_executable_path?
           load_data_from_executable
-        when has_yaml_path?
+        elsif has_yaml_path?
           load_data_from_yaml
         else
           load_data_from_json

--- a/lib/serverkit/loaders/base_loader.rb
+++ b/lib/serverkit/loaders/base_loader.rb
@@ -8,7 +8,7 @@ require "yaml"
 module Serverkit
   module Loaders
     class BaseLoader
-      YAML_EXTNAMES = [".yaml", ".yml"]
+      YAML_EXTNAMES = [".yaml", ".yml"].freeze
 
       # @param [String] path
       def initialize(path)

--- a/lib/serverkit/loaders/recipe_loader.rb
+++ b/lib/serverkit/loaders/recipe_loader.rb
@@ -5,7 +5,7 @@ require "serverkit/recipe"
 module Serverkit
   module Loaders
     class RecipeLoader < BaseLoader
-      DEFAULT_VARIABLES_DATA = {}
+      DEFAULT_VARIABLES_DATA = {}.freeze
 
       # @param [String] path
       # @param [String, nil] variables_path

--- a/lib/serverkit/recipe.rb
+++ b/lib/serverkit/recipe.rb
@@ -17,10 +17,9 @@ module Serverkit
     # @return [Array<Serverkit::Errors::Base>]
     def errors
       @errors ||= begin
-        case
-        when !has_valid_typed_recipe_data?
+        if !has_valid_typed_recipe_data?
           errors_for_invalid_typed_recipe_data
-        when !has_valid_typed_resources_property?
+        elsif !has_valid_typed_resources_property?
           errors_for_invalid_typed_resources_property
         else
           errors_in_resources

--- a/lib/serverkit/resource_builder.rb
+++ b/lib/serverkit/resource_builder.rb
@@ -46,10 +46,9 @@ module Serverkit
 
     # @return [Class]
     def resource_class
-      case
-      when type.nil?
+      if type.nil?
         Resources::Missing
-      when has_known_type?
+      elsif has_known_type?
         Resources.const_get(resource_class_name, false)
       else
         Resources::Unknown

--- a/lib/serverkit/resources/base.rb
+++ b/lib/serverkit/resources/base.rb
@@ -226,10 +226,9 @@ module Serverkit
       # @param [String] command one-line shell script to be executed on remote machine
       # @return [Specinfra::CommandResult]
       def run_command(command)
-        case
-        when cwd
+        if cwd
           command = "cd #{Shellwords.escape(cwd)} && #{command}"
-        when user
+        elsif user
           command = "cd && #{command}"
         end
         unless user.nil?

--- a/lib/serverkit/resources/git.rb
+++ b/lib/serverkit/resources/git.rb
@@ -3,7 +3,7 @@ require "serverkit/resources/base"
 module Serverkit
   module Resources
     class Git < Base
-      DEFAULT_STATE = "cloned"
+      DEFAULT_STATE = "cloned".freeze
 
       attribute :path, required: true, type: String
       attribute :repository, required: true, type: String

--- a/lib/serverkit/resources/line.rb
+++ b/lib/serverkit/resources/line.rb
@@ -42,12 +42,11 @@ module Serverkit
 
       # @return [String]
       def applied_remote_file_content
-        case
-        when absent?
+        if absent?
           content.delete(line)
-        when insert_after
+        elsif insert_after
           content.insert_after(Regexp.new(insert_after), line)
-        when insert_before
+        elsif insert_before
           content.insert_before(Regexp.new(insert_before), line)
         else
           content.append(line)
@@ -69,10 +68,9 @@ module Serverkit
       end
 
       def has_correct_line?
-        case
-        when present? && !has_matched_line?
+        if present? && !has_matched_line?
           false
-        when !present? && has_matched_line?
+        elsif !present? && has_matched_line?
           false
         else
           true

--- a/lib/serverkit/resources/line.rb
+++ b/lib/serverkit/resources/line.rb
@@ -8,7 +8,7 @@ module Serverkit
     #     path: /etc/sudoers
     #     line: "#includedir /etc/sudoers.d"
     class Line < Base
-      DEFAULT_STATE = "present"
+      DEFAULT_STATE = "present".freeze
 
       attribute :path, required: true, type: String
       attribute :insert_after, type: String

--- a/lib/serverkit/resources/template.rb
+++ b/lib/serverkit/resources/template.rb
@@ -5,7 +5,7 @@ require "serverkit/resources/remote_file"
 module Serverkit
   module Resources
     class Template < RemoteFile
-      DEFAULT_VARIABLES_DATA = {}
+      DEFAULT_VARIABLES_DATA = {}.freeze
 
       private
 

--- a/lib/serverkit/resources/user.rb
+++ b/lib/serverkit/resources/user.rb
@@ -27,18 +27,17 @@ module Serverkit
 
       # @note Override
       def check
-        case
-        when !has_correct_user?
+        if !has_correct_user?
           false
-        when !has_correct_gid?
+        elsif !has_correct_gid?
           false
-        when !has_correct_home_directory?
+        elsif !has_correct_home_directory?
           false
-        when !has_correct_password?
+        elsif !has_correct_password?
           false
-        when !has_correct_login_shell?
+        elsif !has_correct_login_shell?
           false
-        when !has_correct_uid?
+        elsif !has_correct_uid?
           false
         else
           true

--- a/lib/serverkit/variables.rb
+++ b/lib/serverkit/variables.rb
@@ -22,7 +22,7 @@ module Serverkit
     end
 
     class BindableMash < Hashie::Mash
-      DEFAULT_PROC = -> (hash, key) do
+      DEFAULT_PROC = ->(hash, key) do
         raise KeyError, "key not found: #{key.inspect} (perhaps variables are wrong?)"
       end
 

--- a/lib/serverkit/version.rb
+++ b/lib/serverkit/version.rb
@@ -1,3 +1,3 @@
 module Serverkit
-  VERSION = "0.7.0"
+  VERSION = "0.7.0".freeze
 end

--- a/serverkit.gemspec
+++ b/serverkit.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "specinfra", ">= 2.31.0"
   spec.add_runtime_dependency "unix-crypt"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "rake", "~> 11.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rubocop", "0.37.0"
+  spec.add_development_dependency "rubocop", "0.40.0"
 end

--- a/serverkit.gemspec
+++ b/serverkit.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rubocop", "0.40.0"
+  spec.add_development_dependency "rubocop", "0.45.0"
 end

--- a/serverkit.gemspec
+++ b/serverkit.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rubocop", "0.45.0"
+  spec.add_development_dependency "rubocop", "0.50.0"
 end

--- a/serverkit.gemspec
+++ b/serverkit.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 11.0"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rubocop", "0.29.1"
+  spec.add_development_dependency "rubocop", "0.37.0"
 end


### PR DESCRIPTION
Following #20, I've updated rubocop gem. 

I was going to update rubocop to the latest version, but it's going to be a big change, so I updated to v0.50.

## Changes

- Specify TargetRubyVersion
- Fix `Naming` namespace
- Apply `Style/MutableConstant`, `Style/EmptyCaseCondition` and `Style/SpaceInLambdaLiteral` rules