### PR TITLE
Update rubocop gem to v0.72

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,9 @@ Naming/AccessorMethodName:
 Naming/PredicateName:
   Enabled: false
 
+Naming/UncommunicativeMethodParamName:
+  Enabled: false
+
 Style/AndOr:
   Enabled: false
 
@@ -91,7 +94,10 @@ Style/StringLiterals:
 Style/SymbolArray:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 
 Style/TrailingCommaInArguments:

--- a/bin/serverkit
+++ b/bin/serverkit
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-$LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "serverkit"
 
 Serverkit::Command.new(ARGV).call

--- a/lib/serverkit/actions/apply.rb
+++ b/lib/serverkit/actions/apply.rb
@@ -1,4 +1,5 @@
 require "serverkit/actions/base"
+
 module Serverkit
   module Actions
     class Apply < Base

--- a/lib/serverkit/actions/apply.rb
+++ b/lib/serverkit/actions/apply.rb
@@ -1,6 +1,4 @@
 require "serverkit/actions/base"
-require "thread"
-
 module Serverkit
   module Actions
     class Apply < Base

--- a/lib/serverkit/actions/check.rb
+++ b/lib/serverkit/actions/check.rb
@@ -1,4 +1,5 @@
 require "serverkit/actions/base"
+
 module Serverkit
   module Actions
     class Check < Base

--- a/lib/serverkit/actions/check.rb
+++ b/lib/serverkit/actions/check.rb
@@ -1,6 +1,4 @@
 require "serverkit/actions/base"
-require "thread"
-
 module Serverkit
   module Actions
     class Check < Base

--- a/lib/serverkit/command.rb
+++ b/lib/serverkit/command.rb
@@ -51,8 +51,8 @@ module Serverkit
       else
         raise Errors::UnknownActionNameError, action_name
       end
-    rescue Errors::Base, Psych::SyntaxError, Slop::MissingArgumentError, Slop::MissingOptionError => exception
-      abort "Error: #{exception}"
+    rescue Errors::Base, Psych::SyntaxError, Slop::MissingArgumentError, Slop::MissingOptionError => e
+      abort "Error: #{e}"
     end
 
     private

--- a/lib/serverkit/loaders/base_loader.rb
+++ b/lib/serverkit/loaders/base_loader.rb
@@ -67,7 +67,6 @@ module Serverkit
         @expanded_erb_tempfile ||= Tempfile.new(["", expanded_erb_path_suffix]).tap do |tempfile|
           tempfile << expand_erb
           tempfile.close
-          tempfile
         end
       end
 

--- a/lib/serverkit/resources/template.rb
+++ b/lib/serverkit/resources/template.rb
@@ -23,7 +23,7 @@ module Serverkit
 
       # @return [String] ERB content
       def template_content
-        @template ||= ::File.read(source)
+        @template_content ||= ::File.read(source)
       end
 
       # @note Override

--- a/serverkit.gemspec
+++ b/serverkit.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rubocop", "0.50.0"
+  spec.add_development_dependency "rubocop", "0.53.0"
 end

--- a/serverkit.gemspec
+++ b/serverkit.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "serverkit/version"
 

--- a/serverkit.gemspec
+++ b/serverkit.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rubocop", "0.70.0"
+  spec.add_development_dependency "rubocop", "~> 0.72.0"
 end

--- a/serverkit.gemspec
+++ b/serverkit.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rubocop", "0.53.0"
+  spec.add_development_dependency "rubocop", "0.70.0"
 end


### PR DESCRIPTION
Following #21, I've updated rubocop gem to the latest version, v0.72.