### PR TITLE
Add GitHub Actions badge to README

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 on:
   push:
     branches:
+      - master
       - main
   pull_request:
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Serverkit [![Build Status](https://travis-ci.org/serverkit/serverkit.svg)](https://travis-ci.org/serverkit/serverkit) [![Code Climate](https://codeclimate.com/github/serverkit/serverkit/badges/gpa.svg)](https://codeclimate.com/github/serverkit/serverkit)
+# Serverkit [![Test](https://github.com/serverkit/serverkit/actions/workflows/test.yml/badge.svg)](https://github.com/serverkit/serverkit/actions/workflows/test.yml) [![Code Climate](https://codeclimate.com/github/serverkit/serverkit/badges/gpa.svg)](https://codeclimate.com/github/serverkit/serverkit)
 Assemble servers from your recipe.
 
 ![Server (thx 1041uuu)](/images/server.png)


### PR DESCRIPTION
related. #27

- Add `master` branch as a gh-action trigger since the default branch is `master`
- Remove TravisCI status badge. Add gh-action badge to README.