### PR TITLE
Add Ruby 3.3 to CI environment.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.6
+  SuggestExtensions: false
+  NewCops: disable
 
 Lint/AssignmentInCondition:
   Enabled: false


### PR DESCRIPTION
This PR adds Ruby 3.3 to the CI environment, allowing us to test our code against this version of Ruby.

And disabled `SuggestExtensions` and `NewCops` to avoid the following warning when running `rake test`.

I have confirmed that the test passes in GitHub Action in my repository.

https://github.com/madogiwa0124/serverkit/actions/runs/7405189326