### PR TITLE
:cop: Enable rubocop `Style/FrozenStringLiteralComment`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -104,3 +104,6 @@ Style/TrailingCommaInArguments:
 
 Style/TrivialAccessors:
   Enabled: false
+
+Style/CollectionCompact:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -104,6 +104,3 @@ Style/TrailingCommaInArguments:
 
 Style/TrivialAccessors:
   Enabled: false
-
-Layout/LineLength:
-  Max: 120

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,9 +62,6 @@ Style/DoubleNegation:
 
 Style/EmptyMethod:
   Enabled: false
-
-Style/FrozenStringLiteralComment:
-  Enabled: false
   
 Style/FormatString:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "rubocop/rake_task"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
 

--- a/bin/serverkit
+++ b/bin/serverkit
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "serverkit"

--- a/lib/at_least_one_of_validator.rb
+++ b/lib/at_least_one_of_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_model"
 require "active_support/core_ext/array/conversions"
 require "active_support/core_ext/object/try"

--- a/lib/readable_validator.rb
+++ b/lib/readable_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_model"
 
 class ReadableValidator < ActiveModel::EachValidator

--- a/lib/regexp_validator.rb
+++ b/lib/regexp_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_model"
 
 class RegexpValidator < ActiveModel::EachValidator

--- a/lib/required_validator.rb
+++ b/lib/required_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_model"
 
 class RequiredValidator < ActiveModel::EachValidator

--- a/lib/serverkit.rb
+++ b/lib/serverkit.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require "serverkit/command"
 require "serverkit/version"

--- a/lib/serverkit/actions/apply.rb
+++ b/lib/serverkit/actions/apply.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/actions/base"
 
 module Serverkit

--- a/lib/serverkit/actions/base.rb
+++ b/lib/serverkit/actions/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler"
 require "logger"
 require "serverkit/backends/local_backend"

--- a/lib/serverkit/actions/check.rb
+++ b/lib/serverkit/actions/check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/actions/base"
 
 module Serverkit

--- a/lib/serverkit/actions/inspect.rb
+++ b/lib/serverkit/actions/inspect.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/actions/base"
 
 module Serverkit

--- a/lib/serverkit/actions/validate.rb
+++ b/lib/serverkit/actions/validate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/actions/base"
 
 module Serverkit

--- a/lib/serverkit/backends/base_backend.rb
+++ b/lib/serverkit/backends/base_backend.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/module/delegation"
 require "serverkit/logger"
 

--- a/lib/serverkit/backends/local_backend.rb
+++ b/lib/serverkit/backends/local_backend.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require "serverkit/backends/base_backend"
 require "specinfra"
 
 module Serverkit
   module Backends
     class LocalBackend < BaseBackend
-      HOST = "localhost".freeze
+      HOST = "localhost"
 
       # @note Override
       def host

--- a/lib/serverkit/backends/ssh_backend.rb
+++ b/lib/serverkit/backends/ssh_backend.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "etc"
 require "net/ssh"
 require "serverkit/backends/base_backend"

--- a/lib/serverkit/command.rb
+++ b/lib/serverkit/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rainbow"
 require "serverkit/actions/apply"
 require "serverkit/actions/check"

--- a/lib/serverkit/command.rb
+++ b/lib/serverkit/command.rb
@@ -77,9 +77,7 @@ module Serverkit
         recipe_path: recipe_path,
         variables_path: variables_path,
         ssh_options: ssh_options,
-      }.reject do |key, value|
-        value.nil?
-      end
+      }.compact
     end
 
     def apply
@@ -138,9 +136,7 @@ module Serverkit
       {
         user: command_line_options["ssh-user"],
         keys: keys,
-      }.reject do |key, value|
-        value.nil?
-      end
+      }.compact
     end
   end
 end

--- a/lib/serverkit/errors/attribute_validation_error.rb
+++ b/lib/serverkit/errors/attribute_validation_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/errors/base"
 
 module Serverkit

--- a/lib/serverkit/errors/base.rb
+++ b/lib/serverkit/errors/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Serverkit
   module Errors
     class Base < StandardError

--- a/lib/serverkit/errors/invalid_recipe_type_error.rb
+++ b/lib/serverkit/errors/invalid_recipe_type_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/errors/base"
 
 module Serverkit

--- a/lib/serverkit/errors/invalid_resources_type_error.rb
+++ b/lib/serverkit/errors/invalid_resources_type_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/errors/base"
 
 module Serverkit

--- a/lib/serverkit/errors/missing_action_name_argument_error.rb
+++ b/lib/serverkit/errors/missing_action_name_argument_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/errors/base"
 
 module Serverkit

--- a/lib/serverkit/errors/missing_recipe_path_argument_error.rb
+++ b/lib/serverkit/errors/missing_recipe_path_argument_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/errors/base"
 
 module Serverkit

--- a/lib/serverkit/errors/missing_resource_type_error.rb
+++ b/lib/serverkit/errors/missing_resource_type_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/errors/base"
 
 module Serverkit

--- a/lib/serverkit/errors/non_existent_path_error.rb
+++ b/lib/serverkit/errors/non_existent_path_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/errors/base"
 
 module Serverkit

--- a/lib/serverkit/errors/unknown_action_name_error.rb
+++ b/lib/serverkit/errors/unknown_action_name_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/errors/base"
 
 module Serverkit

--- a/lib/serverkit/errors/unknown_resource_type_error.rb
+++ b/lib/serverkit/errors/unknown_resource_type_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/errors/base"
 
 module Serverkit

--- a/lib/serverkit/loaders/base_loader.rb
+++ b/lib/serverkit/loaders/base_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "erb"
 require "json"
 require "pathname"

--- a/lib/serverkit/loaders/recipe_loader.rb
+++ b/lib/serverkit/loaders/recipe_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/loaders/base_loader"
 require "serverkit/loaders/variables_loader"
 require "serverkit/recipe"

--- a/lib/serverkit/loaders/variables_loader.rb
+++ b/lib/serverkit/loaders/variables_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/loaders/base_loader"
 require "serverkit/variables"
 

--- a/lib/serverkit/logger.rb
+++ b/lib/serverkit/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "logger"
 require "rainbow"
 

--- a/lib/serverkit/recipe.rb
+++ b/lib/serverkit/recipe.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/hash/deep_merge"
 require "serverkit/errors/invalid_recipe_type_error"
 require "serverkit/errors/invalid_resources_type_error"

--- a/lib/serverkit/resource_builder.rb
+++ b/lib/serverkit/resource_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/string/inflections"
 require "serverkit/resources/command"
 require "serverkit/resources/directory"

--- a/lib/serverkit/resources/base.rb
+++ b/lib/serverkit/resources/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_model"
 require "active_model/errors"
 require "active_support/core_ext/module/delegation"

--- a/lib/serverkit/resources/command.rb
+++ b/lib/serverkit/resources/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/resources/base"
 
 module Serverkit

--- a/lib/serverkit/resources/directory.rb
+++ b/lib/serverkit/resources/directory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/resources/entry"
 
 module Serverkit

--- a/lib/serverkit/resources/entry.rb
+++ b/lib/serverkit/resources/entry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "digest"
 require "serverkit/resources/base"
 require "tempfile"

--- a/lib/serverkit/resources/file.rb
+++ b/lib/serverkit/resources/file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/resources/entry"
 
 module Serverkit

--- a/lib/serverkit/resources/git.rb
+++ b/lib/serverkit/resources/git.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require "serverkit/resources/base"
 
 module Serverkit
   module Resources
     class Git < Base
-      DEFAULT_STATE = "cloned".freeze
+      DEFAULT_STATE = "cloned"
 
       attribute :path, required: true, type: String
       attribute :repository, required: true, type: String

--- a/lib/serverkit/resources/group.rb
+++ b/lib/serverkit/resources/group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/resources/base"
 
 module Serverkit

--- a/lib/serverkit/resources/line.rb
+++ b/lib/serverkit/resources/line.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/resources/base"
 
 module Serverkit
@@ -8,7 +10,7 @@ module Serverkit
     #     path: /etc/sudoers
     #     line: "#includedir /etc/sudoers.d"
     class Line < Base
-      DEFAULT_STATE = "present".freeze
+      DEFAULT_STATE = "present"
 
       attribute :path, required: true, type: String
       attribute :insert_after, type: String

--- a/lib/serverkit/resources/missing.rb
+++ b/lib/serverkit/resources/missing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/errors/missing_resource_type_error"
 require "serverkit/resources/base"
 

--- a/lib/serverkit/resources/nothing.rb
+++ b/lib/serverkit/resources/nothing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/resources/base"
 
 module Serverkit

--- a/lib/serverkit/resources/package.rb
+++ b/lib/serverkit/resources/package.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/resources/base"
 
 module Serverkit

--- a/lib/serverkit/resources/recipe.rb
+++ b/lib/serverkit/resources/recipe.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/resources/base"
 
 module Serverkit

--- a/lib/serverkit/resources/remote_file.rb
+++ b/lib/serverkit/resources/remote_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/resources/entry"
 
 module Serverkit

--- a/lib/serverkit/resources/service.rb
+++ b/lib/serverkit/resources/service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/resources/base"
 
 module Serverkit

--- a/lib/serverkit/resources/symlink.rb
+++ b/lib/serverkit/resources/symlink.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/resources/base"
 
 module Serverkit

--- a/lib/serverkit/resources/template.rb
+++ b/lib/serverkit/resources/template.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "erb"
 require "serverkit/loaders/variables_loader"
 require "serverkit/resources/remote_file"

--- a/lib/serverkit/resources/unknown.rb
+++ b/lib/serverkit/resources/unknown.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/errors/unknown_resource_type_error"
 require "serverkit/resources/base"
 

--- a/lib/serverkit/resources/user.rb
+++ b/lib/serverkit/resources/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit/resources/base"
 require "unix_crypt"
 

--- a/lib/serverkit/variables.rb
+++ b/lib/serverkit/variables.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/hash/deep_merge"
 require "hashie/mash"
 

--- a/lib/serverkit/version.rb
+++ b/lib/serverkit/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Serverkit
-  VERSION = "0.9.0".freeze
+  VERSION = "0.9.0"
 end

--- a/lib/type_validator.rb
+++ b/lib/type_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_model"
 
 class TypeValidator < ActiveModel::EachValidator

--- a/serverkit.gemspec
+++ b/serverkit.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "serverkit/version"

--- a/spec/serverkit/command_spec.rb
+++ b/spec/serverkit/command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Serverkit::Command do
   let(:command) do
     described_class.new(argv)

--- a/spec/serverkit/recipe_spec.rb
+++ b/spec/serverkit/recipe_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Serverkit::Recipe do
   let(:recipe) do
     described_class.new(recipe_data)

--- a/spec/serverkit/resource_builder_spec.rb
+++ b/spec/serverkit/resource_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/hash/slice"
 
 RSpec.describe Serverkit::ResourceBuilder do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "serverkit"
 
 RSpec.configure do |config|


### PR DESCRIPTION
- :cop: Enable rubocop `Style/FrozenStringLiteralComment`
- Remove `Layout/LineLength` since the value is default
  - see. https://github.com/rubocop/rubocop/pull/7952
- :cop: Enable rubocop `Style/CollectionCompact` cop