### PR TITLE
fix: Fix a bug where `false` attribute is overwritten by `default` value

### DIFF
--- a/lib/serverkit/resources/base.rb
+++ b/lib/serverkit/resources/base.rb
@@ -24,7 +24,7 @@ module Serverkit
         def attribute(name, options = {})
           default = options.delete(:default)
           define_method(name) do
-            @attributes[name.to_s] || default
+            @attributes.fetch(name.to_s, default)
           end
           validates name, options unless options.empty?
         end

--- a/spec/serverkit/resource_builder_spec.rb
+++ b/spec/serverkit/resource_builder_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/hash/slice"
-
 RSpec.describe Serverkit::ResourceBuilder do
   let(:recipe) do
     Serverkit::Recipe.new(recipe_data)

--- a/spec/serverkit/resources/user_spec.rb
+++ b/spec/serverkit/resources/user_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Serverkit::Resources::User do
+  let(:recipe) { Serverkit::Recipe.new(resources: [attributes]) }
+  let(:attributes) do
+    {
+      "type" => "user",
+    }
+  end
+
+  subject { described_class.new(recipe, attributes) }
+
+  describe "system" do
+    context "system is true" do
+      let(:attributes) do
+        {
+          "type" => "user",
+          "system" => true,
+        }
+      end
+      it { expect(subject.system).to be true }
+    end
+
+    context "system is false" do
+      let(:attributes) do
+        {
+          "type" => "user",
+          "system" => false,
+        }
+      end
+      it { expect(subject.system).to be false }
+    end
+  end
+end


### PR DESCRIPTION
## Issue

When the attribute is `false` or falsy value, the return value defined by`define_method(name)` will always return `default` value.

```rb
define_method(name) do
  false || default
end
```

So, use `Hash#fetch` instead of `Hash#[]`.

## `Hash#fetch` vs `Hash#[]`

```rb
irb(main):001>  a = { x: false, y: nil }
=> {x: false, y: nil}

irb(main):003> a[:x] || true
=> true
irb(main):004> a[:y] || true
=> true
irb(main):005> a[:z] || true
=> true

irb(main):002> a.fetch(:x, true)
=> false
irb(main):003> a.fetch(:y, true)
=> nil
irb(main):004> a.fetch(:z, true)
=> true
```

## Changes

- fix: Fix a bug where `false` attribute is overwritten by default value
- test: Add `Serverkit::Resources::User` spec to test falsy value
- chore: Remove unnecessary require
