### PR TITLE
docs: Update Plug-in links / Better console highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ serverkit apply recipe.yml
  - [serverkit-karabiner](https://github.com/serverkit/serverkit-karabiner)
  - [serverkit-rbenv](https://github.com/serverkit/serverkit-rbenv)
  - [serverkit-login_items](https://github.com/take/serverkit-login_items)
- - [serverkit-vscode](https://github.com/toshimaru/serverkit-vscode)
+ - [serverkit-vscode](https://github.com/serverkit/serverkit-vscode)
 - [Vagrant integration](/doc/vagrant_integration.md)
 
 ## Similar tools

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ $ serverkit apply recipe.yml
  - [serverkit-rbenv](https://github.com/serverkit/serverkit-rbenv)
  - [serverkit-login_items](https://github.com/take/serverkit-login_items)
  - [serverkit-vscode](https://github.com/serverkit/serverkit-vscode)
+ - [serverkit-mise](https://github.com/serverkit/serverkit-mise)
 - [Vagrant integration](/doc/vagrant_integration.md)
 
 ## Similar tools

--- a/doc/action_apply.md
+++ b/doc/action_apply.md
@@ -5,7 +5,7 @@ between the specified recipe and the state of the target host.
 ## Successful case
 If no error was found, it returns exit status 0.
 
-```
+```console
 $ serverkit apply recipe.yml
 [SKIP] homebrew mysql on localhost
 [SKIP] homebrew redis on localhost
@@ -20,7 +20,7 @@ $ echo $?
 ## Failed case
 If any error was found, it returns exit status 1.
 
-```
+```console
 $ serverkit apply recipe.yml
 [SKIP] homebrew mysql on localhost
 [SKIP] homebrew redis on localhost
@@ -39,7 +39,7 @@ You can run serverkit on multiple hosts by passing hosts in comma-separated styl
 If you want to specify SSH configuration, write it into your ~/.ssh/config.
 This option is also available in `serverkit check` action.
 
-```
+```console
 $ serverkit apply recipe.yml --hosts=alpha.example.com
 $ serverkit apply recipe.yml --hosts=alpha.example.com,bravo.example.com
 $ serverkit apply recipe.yml --hosts=app1,app2,app3
@@ -53,6 +53,6 @@ and all shell commands executed on hosts are logged with DEBUG level.
 The log output is colored by default.
 Pass `--no-color` option if you want to disable colored log outputs.
 
-```
+```console
 $ serverkit apply recipe.yml --hosts=alpha.example.com --log-level=debug --no-color
 ```

--- a/doc/action_check.md
+++ b/doc/action_check.md
@@ -8,7 +8,7 @@ See [/doc/action_apply.md] for more details.
 ## Same case
 If no difference was detected, it returns exit status 0.
 
-```
+```console
 $ serverkit check recipe.yml
 [ OK ] homebrew mysql on localhost
 [ OK ] homebrew redis on localhost
@@ -23,7 +23,7 @@ $ echo $?
 ## Different case
 If any difference was detected, it returns exit status 1.
 
-```
+```console
 $ serverkit check recipe.yml
 [ OK ] homebrew mysql on localhost
 [ OK ] homebrew redis on localhost

--- a/doc/action_inspect.md
+++ b/doc/action_inspect.md
@@ -4,7 +4,7 @@ This action is useful as your recipe grows to a large size with using variables,
 You can specify your recipe by passing its path in the same way as the other actions.
 
 ## Example
-```
+```console
 $ serverkit inspect recipe.yml
 {
   "resources": [

--- a/doc/action_validate.md
+++ b/doc/action_validate.md
@@ -6,7 +6,7 @@ Note that the other actions (e.g. `inspect`, `check`, `apply`) also runs validat
 ## Successful case
 If no error found, it returns exit status 0.
 
-```
+```console
 $ serverkit validate recipe.yml
 $ echo $?
 0
@@ -15,7 +15,7 @@ $ echo $?
 ## Failed case
 If any error found, it reports errors and returns exit status 1.
 
-```
+```console
 $ serverkit validate recipe.yml
 Error: source attribute is required in remote_file resource
 Error: path attribute can't be unreadable path in recipe resource

--- a/doc/install.md
+++ b/doc/install.md
@@ -12,7 +12,7 @@ source "https://rubygems.org"
 gem "serverkit"
 ```
 
-```
+```console
 $ gem install bundler
 $ bundle install
 ```
@@ -21,7 +21,7 @@ $ bundle install
 Instead you can simply install serverkit by `gem` command,
 while you cannot use plugins without bundler.
 
-```
+```console
 $ gem install serverkit
 ```
 
@@ -30,7 +30,7 @@ If you want to install serverkit from source code for any reason,
 you can `git clone` the source code and `rake install` it.
 bundler and git are both required in this method.
 
-```
+```console
 $ git clone https://github.com/serverkit/serverkit.git
 $ cd serverkit
 $ bundle install

--- a/doc/recipe.md
+++ b/doc/recipe.md
@@ -11,7 +11,7 @@ A recipe can be specified as a path to one of the following patterns:
 - Executable to output JSON
 - Directory including recipe files recursively
 
-```
+```console
 $ serverkit apply recipe
 $ serverkit apply recipe.json
 $ serverkit apply recipe.json.erb
@@ -70,6 +70,6 @@ handlers:
     script: killall Dock
 ```
 
-```
+```console
 $ serverkit apply recipe.yml.erb --variables=variables.yml
 ```

--- a/doc/vagrant_integration.md
+++ b/doc/vagrant_integration.md
@@ -7,7 +7,7 @@ One is to use pass the machine's host name via `--hosts=` option like below.
 Note that `vagrant ssh-config` command outputs SSH configuration for the machine on vagrant
 with `Host default`, and serverkit will use it by `--hosts=default` option.
 
-```
+```console
 $ vagrant ssh-config >> ~/.ssh/config
 $ serverkit apply recipe.yml --hosts=default
 ```
@@ -28,7 +28,7 @@ Vagrant.configure("2") do |config|
 end
 ```
 
-```
+```console
 $ vagrant plugin install vagrant-serverkit
 $ vagrant up
 ```


### PR DESCRIPTION
- docs: Update Plug-in links
  - update: https://github.com/serverkit/serverkit-vscode (formerly toshimaru/serverkit-vscode )
  - added: https://github.com/serverkit/serverkit-mise
- chore: Use `console` syntax highlight for terminal commands

with `console`:

```console
$ serverkit apply recipe.yml
[SKIP] homebrew mysql on localhost
```

without `console`:

```
$ serverkit apply recipe.yml
[SKIP] homebrew mysql on localhost
```